### PR TITLE
Add TASKHAWK_POST_PROCESS_HOOK

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -105,6 +105,10 @@ It's recommended that this function be declared with ``**kwargs`` so it doesn't 
 
 optional; fully-qualified function name
 
+**TASKHAWK_POST_PROCESS_HOOK**
+
+Same as ``TASKHAWK_PRE_PROCESS_HOOK`` but executed after task processing.
+
 **TASKHAWK_QUEUE**
 
 The name of the taskhawk queue (exclude the ``TASKHAWK-`` prefix).

--- a/taskhawk/conf/__init__.py
+++ b/taskhawk/conf/__init__.py
@@ -17,6 +17,7 @@ _DEFAULTS = {
     'IS_LAMBDA_APP': False,
     'TASKHAWK_DEFAULT_HEADERS': 'taskhawk.conf.default_headers_hook',
     'TASKHAWK_PRE_PROCESS_HOOK': 'taskhawk.conf.noop_hook',
+    'TASKHAWK_POST_PROCESS_HOOK': 'taskhawk.conf.noop_hook',
     'TASKHAWK_QUEUE': None,
     'TASKHAWK_SYNC': False,
     'TASKHAWK_TASK_CLASS': 'taskhawk.task_manager.Task',
@@ -24,7 +25,12 @@ _DEFAULTS = {
 
 
 # List of settings that may be in string import notation.
-_IMPORT_STRINGS = ('TASKHAWK_DEFAULT_HEADERS', 'TASKHAWK_PRE_PROCESS_HOOK', 'TASKHAWK_TASK_CLASS')
+_IMPORT_STRINGS = (
+    'TASKHAWK_DEFAULT_HEADERS',
+    'TASKHAWK_PRE_PROCESS_HOOK',
+    'TASKHAWK_POST_PROCESS_HOOK',
+    'TASKHAWK_TASK_CLASS',
+)
 
 
 def default_headers_hook():

--- a/taskhawk/consumer.py
+++ b/taskhawk/consumer.py
@@ -118,6 +118,11 @@ def fetch_and_process_messages(queue_name: str, queue, num_messages: int = 1, vi
         try:
             message_handler_sqs(queue_message)
             try:
+                settings.TASKHAWK_POST_PROCESS_HOOK(queue_name=queue_name, sqs_queue_message=queue_message)
+            except Exception:
+                logger.exception(f'Exception in post process hook for message from {queue_name}')
+                raise
+            try:
                 queue_message.delete()
             except Exception:
                 logger.exception(f'Exception while deleting message from {queue_name}')
@@ -141,6 +146,8 @@ def process_messages_for_lambda_consumer(lambda_event: dict) -> None:
         settings.TASKHAWK_PRE_PROCESS_HOOK(sns_record=record)
 
         message_handler_lambda(record)
+
+        settings.TASKHAWK_POST_PROCESS_HOOK(sns_record=record)
 
 
 def listen_for_messages(


### PR DESCRIPTION
`TASKHAWK_PRE_PROCESS_HOOK` is for initialization, but initialization often comes with required cleanup, so `TASKHAWK_POST_PROCESS_HOOK` is useful too.